### PR TITLE
Bump semantic-ui-react from 1.3.1 to 2.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "peerDependencies": {
     "react": "^16.0.0",
-    "semantic-ui-react": "^1.3.1"
+    "semantic-ui-react": "^2.0.3"
   },
   "devDependencies": {
     "@auth0/auth0-spa-js": "^1.12.1",


### PR DESCRIPTION
## What?
peerDependency の `semantic-ui-react` を `^1.3.1` から `^2.0.3` にアップデート

## Why?
アップデートのため
