### PR TITLE
fix HealthCheck to export itself as named component

### DIFF
--- a/src/components/HealthCheck.stories.tsx
+++ b/src/components/HealthCheck.stories.tsx
@@ -1,13 +1,12 @@
-import React from 'react';
-import { storiesOf } from '@storybook/react';
-import HealthCheck from "./HealthCheck";
+import React from 'react'
+import { HealthCheck } from './HealthCheck'
+import { Story } from '@storybook/react'
 
+export default {
+  component: HealthCheck,
+  title: 'HealthCheck'
+}
 
-storiesOf('HealthCheck/HealthCheck', module)
-  .add('default', () =>
-    <div>
-      <HealthCheck/>
-    </div>
-  )
+const Template: Story = (args) => <HealthCheck {...args} />
 
-
+export const Default = Template.bind({})

--- a/src/components/HealthCheck.tsx
+++ b/src/components/HealthCheck.tsx
@@ -1,6 +1,9 @@
 import React from 'react'
 
-const HealthCheck = () => {
+const Component = (): JSX.Element => {
   return <div className='health-check'>OK</div>
 }
-export default HealthCheck
+export { Component as HealthCheck }
+
+// this is remain for compatibility
+export default Component


### PR DESCRIPTION
## What?
- fix HealthCheck to export itself as named component
- fix code style of storybook to currently recommended

## Why?
- default exports is discouraged (I think)

## See also
- https://storybook.js.org/docs/react/api/csf
- https://typescript-jp.gitbook.io/deep-dive/main-1/defaultisbad