### PR TITLE
adapt to some Material UI component

### DIFF
--- a/src/components/ToolBar.stories.tsx
+++ b/src/components/ToolBar.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { ToolBar } from './ToolBar'
+import Button from '@material-ui/core/Button'
 
 export default {
   component: ToolBar,
@@ -8,11 +9,8 @@ export default {
 
 export const Default = (): JSX.Element => (
   <ToolBar>
+    <input />
     <button>Test</button>
-    {/* if you want to use shrinkable content (e.g. input) in ToolBox, you should protect it by using flex-shrink: 0 */}
-    <div style={{ flexShrink: 0 }}>
-      <input />
-    </div>
   </ToolBar>
 )
 
@@ -34,17 +32,13 @@ export const HorizontalScrolling = (): JSX.Element => (
     <div>test</div>
     <div style={{ overflowX: 'auto' }}>
       <ToolBar>
-        <div style={{ flexShrink: 0 }}>
-          <input />
-        </div>
+        <input />
         {Array(40)
           .fill(0)
           .map((_, i) => (
             <button key={i}>Test</button>
           ))}
-        <div style={{ flexShrink: 0 }}>
-          <input />
-        </div>
+        <input />
       </ToolBar>
     </div>
   </div>
@@ -71,5 +65,17 @@ export const RegressionTestForPR33 = (): JSX.Element => (
     >
       <div style={{ height: '200vh' }} />
     </div>
+  </div>
+)
+
+export const NarrowViewPort = (): JSX.Element => (
+  <div style={{ overflow: 'auto', width: '10vw' }}>
+    <ToolBar>
+      <Button>This is test</Button>
+      <span style={{ width: '10px', flexShrink: 0 }} />
+      <div style={{ flexShrink: 0 }}>
+        <Button>This is test</Button>
+      </div>
+    </ToolBar>
   </div>
 )

--- a/src/components/ToolBar.tsx
+++ b/src/components/ToolBar.tsx
@@ -11,27 +11,19 @@ type ContainerProps = {
 
 const Component = ({ classes, children }: Props): JSX.Element => {
   return (
-    <div className={classes.toolBar}>
-      <span className={classes.span} />
-      <div className={classes.toolsContainer}>{children}</div>
+    <div className={classes.toolsContainer}>
+      <span style={{ flex: 1 }} />
+      {children}
     </div>
   )
 }
 
 const useStyles = makeStyles(() => ({
-  toolBar: {
-    display: 'flex',
-    flexShrink: 0,
-    overflowX: 'auto'
-  },
-  span: {
-    flex: 1
-  },
   toolsContainer: {
     alignItems: 'center',
     display: 'flex',
-    flex: 0,
-    justifyContent: 'flex-end'
+    flexShrink: 0,
+    textAlign: 'right'
   }
 }))
 


### PR DESCRIPTION
## What?
- Material UI の Button, Input コンポーネントを ToolBar の中に入れてもバグらないように変更

## Why?
- Material UI コンポーネント flexShrink: 0 を持つ div の中に入れると，↓ のように span 要素が食い込むバグが発生したため
![image (3)](https://user-images.githubusercontent.com/72174933/119164904-dddcdf80-ba97-11eb-8816-25cb60d8ef3b.png)
- この挙動のせいで，ビューポートの幅が狭くなったときに変な挙動になった