### PR TITLE
fix PerPageSeletct

### DIFF
--- a/src/components/PerPageSelect.tsx
+++ b/src/components/PerPageSelect.tsx
@@ -36,6 +36,7 @@ const Component = ({
         onChange={handleChange}
         size='small'
         labelId={labelId}
+        variant='outlined'
       >
         {values.map((value) => (
           <MenuItem key={value} value={value}>


### PR DESCRIPTION
## What?
- `variant="outlined"` を指定

## Why?
- デフォルト値は `variant="outlined"` のはずなのだが，app-data-browser-next で使ったら，`variant="standard"` の見た目になったため