### PR TITLE
Fix openapi-typesctipt-codegen option

### DIFF
--- a/bin/generate_openapi.sh
+++ b/bin/generate_openapi.sh
@@ -47,6 +47,6 @@ do
 #    -i /local/schema.yaml \
 #    -g typescript-axios \
 #    -o /local/client
-  npx openapi-typescript-codegen --input ${outdir}/schema.yaml --output ${outdir}/client
+  npx openapi-typescript-codegen --input ${outdir}/schema.yaml --output ${outdir}/client --useOptions
   echo "export * as ${apiName} from './${apiName}/client'" >> ${apidir}/index.tsx
 done


### PR DESCRIPTION
## What?
- Fix openapi-typesctipt-codegen option

## Why?
- クライアントの引数がオブジェクトの方が何かと便利だから