### PR TITLE
Expand QueryStringConvertibleObject

### DIFF
--- a/src/utils/queryStringController.test.ts
+++ b/src/utils/queryStringController.test.ts
@@ -61,9 +61,17 @@ describe('resetQueryString', () => {
 
 describe('objToQueryString', () => {
   test('can convert object to query string', () => {
-    const obj = { sample: 'test', test: 123, experiment: undefined, hoge: null }
+    const obj = {
+      sample: 'test',
+      test: 123,
+      experiment: undefined,
+      hoge: null,
+      array: ['test', 1234]
+    }
     const queryString = objToQueryString(obj)
-    expect(queryString === '?sample=test&test=123').toBeTruthy()
+    expect(
+      queryString === '?sample=test&test=123&array=["test",1234]'
+    ).toBeTruthy()
   })
 })
 

--- a/src/utils/queryStringController.ts
+++ b/src/utils/queryStringController.ts
@@ -38,18 +38,26 @@ export function resetQueryString(method: 'push' | 'replace'): void {
 
 export type QueryStringConvertibleObj = Record<
   string,
-  string | number | undefined | null
+  string | number | undefined | null | (string | number)[]
 >
 
 export function objToQueryString(obj: QueryStringConvertibleObj): string {
   let flag = true
   let paramString = ''
   for (const [key, value] of Object.entries(obj)) {
-    if (flag && value != null) {
-      paramString += `?${key}=${value}`
-      flag = false
-    } else if (value != null) {
-      paramString += `&${key}=${value}`
+    if (value != null) {
+      if (flag) {
+        paramString += '?'
+        flag = false
+      } else {
+        paramString += '&'
+      }
+
+      if (Array.isArray(value)) {
+        paramString += `${key}=${JSON.stringify(value)}`
+      } else {
+        paramString += `${key}=${value}`
+      }
     }
   }
   return paramString


### PR DESCRIPTION
## What?
- Expand QueryStringConvertibleObject

## Why?
- queryString に array 型を求める API があるから
