### PR TITLE
Export createFilterOptionsForMultiSelect

### DIFF
--- a/src/components/MultiSelect.tsx
+++ b/src/components/MultiSelect.tsx
@@ -260,5 +260,5 @@ const Container = <
 }
 
 export { Container as MultiSelect }
-export { createFilterOptions } from '@material-ui/core/Autocomplete'
+export { createFilterOptions as createFilterOptionsForMultiSelect } from '@material-ui/core/Autocomplete'
 export type { ContainerProps as MultiSelectProps }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,7 +14,10 @@ export type { FooterProps } from './components/Footer'
 export { Header } from './components/Header'
 export { HealthCheck } from './components/HealthCheck'
 export { LoadingIndicator } from './components/LoadingIndicator'
-export { MultiSelect } from './components/MultiSelect'
+export {
+  MultiSelect,
+  createFilterOptionsForMultiSelect
+} from './components/MultiSelect'
 export type { MultiSelectProps } from './components/MultiSelect'
 export { PageWrapper } from './components/PageWrapper'
 export type { PageWrapperProps } from './components/PageWrapper'


### PR DESCRIPTION
## What?
- Export createFilterOptionsForMultiSelect

## Why?
- 作成可能なタイプのマルチセレクタを実装するのに必要だから
