### PR TITLE
Fix bug that index.d.ts is not generated

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,8 @@
     "strict": true,
     "strictNullChecks": true,
     "suppressImplicitAnyIndexErrors": true,
-    "target": "ESNext"
+    "target": "ESNext",
+    "downlevelIteration": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist", "example"]


### PR DESCRIPTION
## What?
- Fix bug that index.d.ts is not generated

## Why?
- 理由は分からないが，index.d.ts が生成されない
- 色々試してるうちに downlevelItelation を true にしたら生成されるようになった

## See also
何も分からないまま症状だけ消えた形なので，ここに至った経緯を書いておきます
- コミットを遡ってみたら，PageTemplate が追加されたところで同じ現象が起きるようになっていた
- PageTemplate の中身を
```
const Component = 'test'
export { Component as PageTemplate }
```
  という，どう頑張ってもバグが起きそうにないものにしても index.d.ts は生成されなかった
- data-browser の tsconfig.json をコピペして，重複部分を削除したら上手くいった
- 上記の設定値の中で組み合わせを試していくうちに，compilerOption.downlevelIteration: true だけ追加すれば index.d.ts が生成されるようになることを発見した
- t[ypescript のドキュメントを見る限り，全然関係なさそうなオプションではある](https://www.typescriptlang.org/tsconfig#downlevelIteration)