### PR TITLE
stop importing package.json to fix bugs that index.d.ts is not genarated

### DIFF
--- a/src/components/PageTemplate.tsx
+++ b/src/components/PageTemplate.tsx
@@ -3,10 +3,9 @@ import { PageWrapper } from './PageWrapper'
 import { PageBody } from './PageBody'
 import { PageContainer } from './PageContainer'
 import { PageToolBar } from './PageToolBar'
-import { repository } from '../../package.json'
 
 const Component = (): JSX.Element => (
-  <PageWrapper repository={repository}>
+  <PageWrapper repository='test'>
     <PageContainer>
       <PageToolBar />
       <PageBody>body</PageBody>


### PR DESCRIPTION
## What?
- Stop importing package.json to fix bugs that index.d.ts is not genarated

## Why?
- To generate index.d.ts
