### PR TITLE
Use Node v14 instead of v16

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
-        node-version: '16'
+        node-version: '14'
         registry-url: 'https://npm.pkg.github.com'
     - name: Setup ssh-agent
       uses: webfactory/ssh-agent@v0.4.1


### PR DESCRIPTION
## What?
自動リリースの CI で使う Node のバージョンを v16 から v14 に変更

## Why?
v16 を使うと package-lock.json のロックバージョンが2になってしまうから

## Note
10月に v16 がアクティブな LTS になったら v16 に移行する予定

## See also [Optional]
https://human-dataware-lab.slack.com/archives/G01JKRWFW1G/p1623832614024400?thread_ts=1623825741.009300&cid=G01JKRWFW1G
