### PR TITLE
Fix `repository` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "Common components for dataware-tools",
   "author": "dataware-tools",
   "license": "Apache-2.0",
-  "repository": "dataware-tools/app-common",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dataware-tools/app-common.git"
+  },
   "main": "dist/index.js",
   "module": "dist/index.modern.js",
   "source": "src/index.ts",


### PR DESCRIPTION
## What?
package.json の `repository` の部分を修正

## Why?
GitHub Package Registry がリポジトリを認識できるようにするため  
参考: https://qiita.com/nall/items/5e94f37288c3e796a85e