### PR TITLE
Support cancenl closing ConfirmModal

### DIFF
--- a/src/components/ConfimModal.stories.tsx
+++ b/src/components/ConfimModal.stories.tsx
@@ -12,7 +12,10 @@ const Template: Story<ConfirmModalProps> = (args) => <ConfirmModal {...args} />
 
 export const Default = Template.bind({})
 Default.args = {
-  onClose: (res) => window.alert(res),
+  onClose: (res) => {
+    window.alert(res)
+    return {}
+  },
   body: 'This is test! please click button!',
   title: 'test'
 }

--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -15,7 +15,12 @@ type ContainerProps = {
   cancelText?: string
   cancelButtonProps?: ButtonProps
   reverseButtons?: boolean
-  onClose: (confirmResult: boolean) => void
+  onClose: (
+    confirmResult: boolean
+  ) =>
+    | Promise<{ cancelCloseModal?: boolean } | undefined>
+    | { cancelCloseModal?: boolean }
+    | undefined
 } & Omit<ConfirmModalBaseProps, 'buttons' | 'open'>
 
 const Component = ({
@@ -61,13 +66,19 @@ const Container = ({
 }: ContainerProps): JSX.Element | null => {
   const [open, setOpen] = useState(true)
 
-  const onCancel = () => {
-    onClose(false)
+  const onCancel = async () => {
+    const res = await onClose(false)
+    if (res?.cancelCloseModal) {
+      return
+    }
     setOpen(false)
   }
 
-  const onConfirm = () => {
-    onClose(true)
+  const onConfirm = async () => {
+    const res = await onClose(true)
+    if (res?.cancelCloseModal) {
+      return
+    }
     setOpen(false)
   }
 

--- a/src/components/ConfirmModalBase.tsx
+++ b/src/components/ConfirmModalBase.tsx
@@ -9,8 +9,8 @@ import { DialogMain } from './dialog/DialogMain'
 
 type Props = {
   open: boolean
-  body?: string
-  title?: string
+  body?: ReactNode
+  title?: ReactNode
   height?: string
   buttons: ReactNode
 } & Omit<DialogProps, 'onClose'>
@@ -28,9 +28,21 @@ const Component = ({
       <DialogWrapper>
         <DialogContainer height={height}>
           <DialogBody padding='0'>
-            {title ? <DialogTitle>{title}</DialogTitle> : null}
+            {title ? (
+              typeof title === 'string' ? (
+                <DialogTitle>{title}</DialogTitle>
+              ) : (
+                title
+              )
+            ) : null}
             <DialogMain>
-              {body ? <DialogBody>{body}</DialogBody> : null}
+              {body ? (
+                typeof body === 'string' ? (
+                  <DialogBody>{body}</DialogBody>
+                ) : (
+                  body
+                )
+              ) : null}
             </DialogMain>
             <DialogToolBar right={buttons} />
           </DialogBody>

--- a/src/utils/window.tsx
+++ b/src/utils/window.tsx
@@ -22,6 +22,7 @@ const confirm = ({ ...delegated }: ConfirmArgs): Promise<boolean> => {
             onClose={(result) => {
               resolve(result)
               cleanUp()
+              return {}
             }}
             {...delegated}
           />


### PR DESCRIPTION
## What?
- Support cancenl closing ConfirmModal
- Add feature for receiving react component as titile, body to ConfirmModalBase

## Why?
- 中身を弄れたり，閉じるのをキャンセルできると便利なので

## See also
- Related https://github.com/dataware-tools/dataware-tools/issues/59