### PR TITLE
Add utility for extracting common error message from fetch error

### DIFF
--- a/src/api/fetchClient.tsx
+++ b/src/api/fetchClient.tsx
@@ -39,7 +39,7 @@ const fetchFileProvider = async <T, U>(
 }
 
 type FetchErrorType = {
-  body?: { detail?: unknown; instruction: unknown }
+  body?: { detail?: unknown; instruction?: unknown }
   status: number
 }
 

--- a/src/api/fetchClient.tsx
+++ b/src/api/fetchClient.tsx
@@ -78,5 +78,6 @@ export {
   fetchAPI,
   fetchMetaStore,
   fetchFileProvider,
+  extractReasonFromFetchError,
   extractErrorMessageFromFetchError
 }

--- a/src/api/fetchClient.tsx
+++ b/src/api/fetchClient.tsx
@@ -38,9 +38,12 @@ const fetchFileProvider = async <T, U>(
   return await fetchAPI(fetcher, param)
 }
 
-const extractReasonFromFetchError = (fetchError: {
-  body?: { detail?: unknown }
-}): string => {
+type FetchErrorType = {
+  body?: { detail?: unknown; instruction: unknown }
+  status: number
+}
+
+const extractReasonFromFetchError = (fetchError: FetchErrorType): string => {
   if (typeof fetchError.body?.detail === 'string') {
     return fetchError.body?.detail
   } else if (fetchError.body?.detail) {
@@ -50,9 +53,30 @@ const extractReasonFromFetchError = (fetchError: {
   }
 }
 
+const extractInstructionFromFetchError = (
+  fetchError: FetchErrorType
+): string | undefined => {
+  if (typeof fetchError.body?.instruction === 'string') {
+    return fetchError.body?.instruction
+  } else if (fetchError.body?.instruction) {
+    return JSON.stringify(fetchError.body.instruction)
+  } else if (fetchError.status >= 500 && fetchError.status < 600) {
+    return 'Something went wrong in the server. Please contact the administrator'
+  }
+  return undefined
+}
+
+const extractErrorMessageFromFetchError = (
+  fetchError: FetchErrorType
+): { reason: string; instruction: string | undefined } => {
+  const reason = extractReasonFromFetchError(fetchError)
+  const instruction = extractInstructionFromFetchError(fetchError)
+  return { reason, instruction }
+}
+
 export {
   fetchAPI,
   fetchMetaStore,
   fetchFileProvider,
-  extractReasonFromFetchError
+  extractErrorMessageFromFetchError
 }


### PR DESCRIPTION
## What?
- Add utility for extracting error message from fetch error

## Why?
- フロントアプリで表示するフェッチに関わるエラーメッセージのうち，一般的なものの処理は共通化したいため

## See also
- Related https://github.com/dataware-tools/dataware-tools/issues/63