### PR TITLE
Add delete mode to confirm modal

### DIFF
--- a/src/components/ConfimModal.stories.tsx
+++ b/src/components/ConfimModal.stories.tsx
@@ -17,6 +17,14 @@ Default.args = {
   title: 'test'
 }
 
+export const DeleteMode = Template.bind({})
+DeleteMode.args = {
+  onClose: (res) => window.alert(res),
+  body: 'This is test! please click button!',
+  title: 'Confirm delete',
+  confirmMode: 'delete'
+}
+
 export const ConfirmOnClick = (): JSX.Element => (
   <button
     onClick={async () => {

--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react'
 import Button, { ButtonProps } from '@material-ui/core/Button'
+import { withStyles } from '@material-ui/core/styles'
+import themeInstance from '../theme'
 import { Spacer } from './Spacer'
 import { ConfirmModalBase, ConfirmModalBaseProps } from './ConfirmModalBase'
 
@@ -12,11 +14,23 @@ type Props = {
 type ContainerProps = {
   confirmText?: string
   confirmButtonProps?: ButtonProps
+  confirmMode?: 'default' | 'delete'
   cancelText?: string
   cancelButtonProps?: ButtonProps
   reverseButtons?: boolean
   onClose: (confirmResult: boolean) => void
 } & Omit<ConfirmModalBaseProps, 'buttons' | 'open'>
+
+const DeleteButton = withStyles((theme: typeof themeInstance) => ({
+  root: {
+    color:
+      theme.palette.getContrastText(theme.palette.error.main) + ' !important',
+    backgroundColor: theme.palette.error.main + ' !important',
+    '&:hover': {
+      backgroundColor: theme.palette.error.dark + ' !important'
+    }
+  }
+}))(Button)
 
 const Component = ({
   open,
@@ -27,13 +41,35 @@ const Component = ({
   onCancel,
   cancelButtonProps,
   reverseButtons,
+  confirmMode,
   ...delegated
 }: Props) => {
-  const ConfirmButton = () => (
-    <Button variant='contained' {...confirmButtonProps} onClick={onConfirm}>
-      {confirmText || 'confirm'}
-    </Button>
-  )
+  const ConfirmButton = () => {
+    switch (confirmMode) {
+      case 'delete':
+        return (
+          <DeleteButton
+            variant='contained'
+            {...confirmButtonProps}
+            onClick={onConfirm}
+          >
+            {confirmText || 'delete'}
+          </DeleteButton>
+        )
+
+      case 'default':
+      default:
+        return (
+          <Button
+            variant='contained'
+            {...confirmButtonProps}
+            onClick={onConfirm}
+          >
+            {confirmText || 'confirm'}
+          </Button>
+        )
+    }
+  }
   const CancelButton = () => (
     <Button variant='text' {...cancelButtonProps} onClick={onCancel}>
       {cancelText || 'cancel'}

--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -1,7 +1,5 @@
 import React, { useState } from 'react'
 import Button, { ButtonProps } from '@material-ui/core/Button'
-import { withStyles } from '@material-ui/core/styles'
-import themeInstance from '../theme'
 import { Spacer } from './Spacer'
 import { ConfirmModalBase, ConfirmModalBaseProps } from './ConfirmModalBase'
 
@@ -21,17 +19,6 @@ type ContainerProps = {
   onClose: (confirmResult: boolean) => void
 } & Omit<ConfirmModalBaseProps, 'buttons' | 'open'>
 
-const DeleteButton = withStyles((theme: typeof themeInstance) => ({
-  root: {
-    color:
-      theme.palette.getContrastText(theme.palette.error.main) + ' !important',
-    backgroundColor: theme.palette.error.main + ' !important',
-    '&:hover': {
-      backgroundColor: theme.palette.error.dark + ' !important'
-    }
-  }
-}))(Button)
-
 const Component = ({
   open,
   confirmText,
@@ -48,13 +35,15 @@ const Component = ({
     switch (confirmMode) {
       case 'delete':
         return (
-          <DeleteButton
+          <Button
             variant='contained'
             {...confirmButtonProps}
             onClick={onConfirm}
+            // @ts-expect-error Material-UI v5 beta version will solve this error
+            color='error'
           >
             {confirmText || 'delete'}
-          </DeleteButton>
+          </Button>
         )
 
       case 'default':


### PR DESCRIPTION
## What?

- 確認モーダルに削除時用のスタイルを追加
- Button.color に 'error' を入れて実現
  - Material UI v5 alpha だと型エラーが出るが、 beta で解決する予定のため `@ts-expect-error` で回避

## Why?

削除時の確認モーダルでボタンの色を赤に変更したい

## TODOs

- [x] !important 無しで実装

## See also [Optional]

- Issue: https://github.com/dataware-tools/dataware-tools/issues/27

## Screenshot or video [Optional]

<img width="387" alt="スクリーンショット 2021-08-05 16 43 56" src="https://user-images.githubusercontent.com/13210107/128311626-a477c2d3-3c93-419f-8915-32d162560e98.png">
