### PR TITLE
Use esbuild for bundling instead of microbundle

### DIFF
--- a/bin/esbuild.js
+++ b/bin/esbuild.js
@@ -1,0 +1,19 @@
+/* eslint @typescript-eslint/no-var-requires: 0 */
+const esbuild = require("esbuild");
+const packageInfo = require("../package.json");
+
+const CommonConfig = {
+  entryPoints: ["src/index.ts"],
+  bundle: true,
+  sourcemap: true,
+  target: ["es6"],
+  external: Object.keys(packageInfo.peerDependencies),
+};
+
+esbuild
+  .build({ ...CommonConfig, format: "cjs", outfile: "dist/index.js" })
+  .catch(() => process.exit(1));
+
+esbuild
+  .build({ ...CommonConfig, format: "esm", outfile: "dist/index.modern.js" })
+  .catch(() => process.exit(1));

--- a/package-lock.json
+++ b/package-lock.json
@@ -7308,6 +7308,15 @@
             "yallist": "^3.0.2"
           }
         },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
         "yallist": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -8344,6 +8353,17 @@
         "mkdirp": "^0.5.1",
         "rimraf": "^2.5.4",
         "run-queue": "^1.0.0"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "copy-descriptor": {
@@ -10076,6 +10096,12 @@
       "integrity": "sha512-EmTr31wppcaIAgblChZiuN/l9Y7DPyw8Xtbg7fIVngn6zMW+IEBJDJngeKC3x6wr0V/vcA2wqeFnaw1bFJbDdA==",
       "dev": true
     },
+    "esbuild": {
+      "version": "0.12.28",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.28.tgz",
+      "integrity": "sha512-pZ0FrWZXlvQOATlp14lRSk1N9GkeJ3vLIwOcUoo3ICQn9WNR4rWoNi81pbn6sC1iYUy7QPqNzI3+AEzokwyVcA==",
+      "dev": true
+    },
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -11413,6 +11439,17 @@
             "klaw": "^1.0.0",
             "path-is-absolute": "^1.0.0",
             "rimraf": "^2.2.8"
+          },
+          "dependencies": {
+            "rimraf": {
+              "version": "2.7.1",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+              "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+              "dev": true,
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            }
           }
         }
       }
@@ -17530,6 +17567,17 @@
         "mkdirp": "^0.5.1",
         "rimraf": "^2.5.4",
         "run-queue": "^1.0.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "mri": {
@@ -21518,9 +21566,9 @@
       "dev": true
     },
     "rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "dev": true,
       "requires": {
         "glob": "^7.1.3"

--- a/package.json
+++ b/package.json
@@ -11,12 +11,13 @@
   "main": "dist/index.js",
   "module": "dist/index.modern.js",
   "source": "src/index.ts",
+  "types": "dist/index.d.ts",
   "engines": {
     "node": ">=10"
   },
   "scripts": {
-    "build": "cross-env NODE_OPTIONS=\"--max-old-space-size=4096\" microbundle --no-compress --format modern,cjs",
-    "start": "cross-env NODE_OPTIONS=\"--max-old-space-size=4096\" microbundle watch --no-compress --format modern,cjs",
+    "build": "cross-env NODE_OPTIONS=\"--max-old-space-size=4096\" rimraf dist && node bin/esbuild.js && run-s emit-types",
+    "emit-types": " tsc --emitDeclarationOnly --project tsconfig.json --outDir dist",
     "prepare": "cross-env NODE_OPTIONS=\"--max-old-space-size=4096\" run-s download:catalog generate:openapi build && husky install",
     "test": "cross-env NODE_OPTIONS=\"--max-old-space-size=4096\" run-s lint test:unit test:build test:visual-regression",
     "lint": "cross-env NODE_OPTIONS=\"--max-old-space-size=4096\" run-s lint:eslint lint:stylelint lint:tsc",
@@ -69,6 +70,7 @@
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",
     "cross-env": "^7.0.2",
+    "esbuild": "^0.12.28",
     "eslint": "^7.24.0",
     "eslint-config-prettier": "^8.2.0",
     "eslint-config-standard": "^14.1.1",
@@ -97,6 +99,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "release-it": "^14.9.0",
+    "rimraf": "^3.0.2",
     "semantic-ui-react": "^2.0.3",
     "stylelint": "^13.12.0",
     "stylelint-config-prettier": "^8.0.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,7 @@
     "strict": true,
     "strictNullChecks": true,
     "suppressImplicitAnyIndexErrors": true,
-    "target": "ESNext",
+    "target": "es6",
     "downlevelIteration": true
   },
   "include": ["src"],


### PR DESCRIPTION
## What?
- Use esbuild for bundling instead of microbundle

## Why?
- https://github.com/dataware-tools/app-common/issues/67 を解決して，フェッチ用の Hook を共通化できるようにしたいので
- [単純にビルドが早くなるため](https://github.com/evanw/esbuild#why)

## See also
- Related https://github.com/dataware-tools/dataware-tools/issues/73