### PR TITLE
Close confirm modal on clicked outside of it.

### DIFF
--- a/src/components/AlertModal.tsx
+++ b/src/components/AlertModal.tsx
@@ -26,7 +26,12 @@ export const AlertModalPresentation = ({
     </Button>
   );
   return (
-    <ConfirmModalBase {...delegated} buttons={<ConfirmButton />} open={open} />
+    <ConfirmModalBase
+      {...delegated}
+      buttons={<ConfirmButton />}
+      open={open}
+      onBackdropClick={onConfirm}
+    />
   );
 };
 

--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -71,6 +71,7 @@ export const ConfirmModalPresentation = ({
   return (
     <ConfirmModalBase
       {...delegated}
+      onBackdropClick={onCancel}
       open={open}
       buttons={
         <>


### PR DESCRIPTION
## What?
Close confirm modal on clicked outside of it.

## Why?
こちらの方が UX が良さそうなので

## See also
Related https://github.com/dataware-tools/dataware-tools/issues/85

## Screenshot or video
![CloseConfirmModal](https://user-images.githubusercontent.com/72174933/138679129-8cf59fec-4b17-45e8-b429-a4390e16bcd1.gif)
