### PR TITLE
Drop support for Node 10

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "source": "src/index.ts",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=10",
+    "node": ">=12",
     "npm": ">=7 < 9"
   },
   "scripts": {


### PR DESCRIPTION
## What?
- Drop support for Node 10

## Why?
Node 10 is not LTS now