### PR TITLE
Stop automatic release when Dependabot push

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish:
-    if: "! contains(github.head_ref, 'dependabot')"
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-18.04
     timeout-minutes: 300
 


### PR DESCRIPTION
## What?
Stop automatic release when Dependabot push

## Why?
github.head_ref は PR 時にしか参照できなず，上手く動いていなかったので