### PR TITLE
Add CI for automaticaly merging dependabot patch update

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,22 @@
+name: dependabot-auto-merge
+
+on:
+  workflow_run:
+    types:
+      - completed
+    workflows:
+      # List all required workflow names here.
+      - "Test applications"
+      - "Test"
+
+jobs:
+  merge-me:
+    name: Merge me!
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge me!
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
+        uses: ridedott/merge-me-action@v2.8.35
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRESET: DEPENDABOT_PATCH


### PR DESCRIPTION
## What?
Add CI for automaticaly merging dependabot patch update

## Why?
依存関係のパッチバージョンのアップデートは，CI が通れば自動でマージして欲しいので

## See also
https://github.com/ridedott/merge-me-action