### PR TITLE
Add hooks for using eventListening

### DIFF
--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -1,0 +1,41 @@
+import { useCallback, useEffect, useRef } from "react";
+
+export const usePrevious = <T>(value: T): T | undefined => {
+  const ref = useRef<T>();
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+};
+
+export const useWindowEventListener = (
+  type: keyof WindowEventMap,
+  listener: EventListener,
+  options?: boolean | AddEventListenerOptions | undefined
+): {
+  addEventListener: () => void;
+  removeEventListener: () => void;
+} => {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const eventListener = useCallback(listener, []);
+
+  return {
+    addEventListener: () => {
+      window.addEventListener(type, eventListener, options);
+    },
+    removeEventListener: () => {
+      window.removeEventListener(type, eventListener, options);
+    },
+  };
+};
+
+export const useConfirmClosingWindow = (
+  checkShouldConfirmClosing: () => Promise<boolean> | boolean
+): ReturnType<typeof useWindowEventListener> => {
+  return useWindowEventListener("beforeunload", (e: BeforeUnloadEvent) => {
+    if (checkShouldConfirmClosing()) {
+      e.preventDefault();
+      e.returnValue = "";
+    }
+  });
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,17 +1,8 @@
-import { useEffect, useRef } from "react";
-
-const usePrevious = <T>(value: T): T | undefined => {
-  const ref = useRef<T>();
-  useEffect(() => {
-    ref.current = value;
-  });
-  return ref.current;
-};
-
 const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
-export { usePrevious, sleep };
+export { sleep };
 export * from "./queryStringController";
 export * from "./types";
 export * from "./window";
+export * from "./hooks";


### PR DESCRIPTION
## What?
Add hooks for using eventListening

## Why?
Window で発火したイベント( onbeforeunload とか)をトリガーにして色々やりたいから

## See also
Related https://github.com/dataware-tools/dataware-tools/issues/117

## Screenshot or video
![useConfirmClosingWindow](https://user-images.githubusercontent.com/72174933/150477092-8b3d45d4-b1c0-4a41-9c29-1a40f3db5ab0.gif)

