### PR TITLE
Add github.release setting to release-it

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -3,6 +3,9 @@
     "requireCleanWorkingDir": false,
     "requireBranch": "master"
   },
+  "github": {
+    "release": true
+  },
   "plugins": {
     "@csmith/release-it-calver-plugin": {
       "format": "YY.MM.minor"


### PR DESCRIPTION
## What?

release-itの設定に `github.release: true` を追加

## Why?

2022/3/15あたりからrelease-itが動作していない
https://github.com/dataware-tools/app-common/actions/workflows/auto-release.yml

## See also [Optional]

https://github.com/release-it/release-it/blob/14.14.3/docs/github-releases.md#automated
