### PR TITLE
Change env var of auto-release CI to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -28,4 +28,4 @@ jobs:
       - run: npm install
       - run: npm run release-it
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What?

auto-release CIの環境変数 `NODE_AUTH_TOKEN` を `GITHUB_TOKEN` に変更

## Why?

- auto-releaseが動かない
- release-itのドキュメントにはGITHUB_TOKEN環境変数を確認するとあったため
  https://github.com/release-it/release-it/blob/14.14.3/docs/github-releases.md#automated
