### PR TITLE
Drop node v12 from supporting

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "source": "src/index.ts",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=12",
+    "node": ">=14",
     "npm": ">=7 < 9"
   },
   "scripts": {


### PR DESCRIPTION
## What?
Drop node v12 from supporting

## Why?
Node v12 is not maintained now