### PR TITLE
Skip release ci on renovate PR

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish:
-    if: github.actor != 'dependabot[bot]'
+    if: ! startsWith(github.ref_name,'renovate/')
     runs-on: ubuntu-18.04
     timeout-minutes: 300
 


### PR DESCRIPTION
## What?
Skip release ci on renovate PR

## Why?
renovate が依存関係を更新するときにはリリースしたくないから