### PR TITLE
Fix renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>dataware-tools/renovate-config"
-  ]
+  ],
+  "packageRules": [ {
+      "matchDepTypes": [
+        "peerDependencies"
+      ],
+      "rangeStrategy": "bump"
+    }]
 }


### PR DESCRIPTION
## What?
Fix renovate-config

## Why?
ライブラリのアップデート時に前のバージョンとの互換性が取れないことが多いから