### PR TITLE
Bump package version to fix error on CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dataware-tools/app-common",
-  "version": "22.7.27",
+  "version": "22.7.28",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dataware-tools/app-common",
-      "version": "22.7.27",
+      "version": "22.7.28",
       "license": "Apache-2.0",
       "devDependencies": {
         "@auth0/auth0-react": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dataware-tools/app-common",
-  "version": "22.7.27",
+  "version": "22.7.28",
   "description": "Common components for dataware-tools",
   "author": "dataware-tools",
   "license": "Apache-2.0",


### PR DESCRIPTION
## What?
Bump package version to fix error on CI

## Why?
[Automatic release workflow](https://github.com/dataware-tools/app-common/runs/7316000117?check_suite_focus=true#step:8:282) がバグってたから