### PR TITLE
Add utility function that enqueues error toast

### DIFF
--- a/src/components/toast/index.ts
+++ b/src/components/toast/index.ts
@@ -4,3 +4,4 @@ export { Toaster } from "./Toaster";
 export type { ToasterProps } from "./Toaster";
 export { Toast } from "./Toast";
 export type { ToastProps } from "./Toast";
+export { enqueueErrorToastForFetchError } from "./utils";

--- a/src/components/toast/utils.tsx
+++ b/src/components/toast/utils.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { toast } from "react-toastify";
+
+import { extractErrorMessageFromFetchError } from "../../api/fetchClient";
+import { ErrorMessage } from "../ErrorMessage";
+import { ToastHavingDetailInfo } from "./ToastHavingDetailInfo";
+
+export const enqueueErrorToastForFetchError = (
+  message: string,
+  error: any
+): void => {
+  const { reason, instruction } = extractErrorMessageFromFetchError(error);
+  toast.error(
+    <ToastHavingDetailInfo
+      detailContent={
+        <ErrorMessage
+          variant="transparent"
+          reason={reason}
+          instruction={instruction}
+        />
+      }
+    >
+      {message}
+    </ToastHavingDetailInfo>
+  );
+};


### PR DESCRIPTION
## What?

エラー通知のトーストを表示する関数をapp-commonに移動

## Why?

各アプリで共通しているため

## See also [Optional]

- https://github.com/dataware-tools/app-data-browser-next/pull/485
- https://github.com/dataware-tools/app-user-manager/pull/367
