### PR TITLE
Add Ci for publishing to npm on release in github

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,15 +1,11 @@
-name: Automatic release
+name: Publish to github npm registry
 
 on:
-  pull_request:
-    types:
-      - closed
-    branches:
-      - master
+  release:
+    types: [published]
 
 jobs:
   publish:
-    if: github.event.pull_request.merged == true && !(startsWith(github.ref_name,'renovate/'))
     runs-on: ubuntu-18.04
     timeout-minutes: 300
 
@@ -23,21 +19,13 @@ jobs:
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-      - name: git config
-        run: |
-          git config --global user.email "hdl-service@hdwlab.co.jp"
-          git config --global user.name "hdl-service"
-      # WARNING: This may lead commiting .npmrc with token in it (add .npmrc to .gitignore before uncommentint the following block)
-      # https://github.com/release-it/release-it/blob/14.14.3/docs/ci.md#npm
-      - name: npm config
+
+      - name: Install deps && build package
+        run: npm install
         env:
-          NPM_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
-        run: |
-          npm config set //npm.pkg.github.com/:_authToken $NPM_TOKEN
-          npm config set @dataware-tools:registry=https://npm.pkg.github.com
-      - run: npm install
+          NODE_AUTH_TOKEN: ${{secrets.REPO_ACCESS_TOKEN}}
+
+      - name: publish to npm
+        run: npm version ${GITHUB_REF##*/} && npm publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
-      - run: npm run release-it
-        env:
-          GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What?
Add Ci for publishing to npm on release in github

## Why?
Github のリリース時に npm に publish する方が諸々都合がいいから

## See also 
https://github.com/dataware-tools/app-common/releases/tag/v0.0.0-test1
